### PR TITLE
Add in an exit code of 1 on test failure

### DIFF
--- a/lib/testosterone.js
+++ b/lib/testosterone.js
@@ -5,6 +5,8 @@
  */
 require('colors');
 
+var FAILURE_EXIT_CODE = 1;
+
 module.exports = function (config) {
 
   var _util = require('util')
@@ -36,7 +38,7 @@ module.exports = function (config) {
                 require('assert')[fn].apply(this, [].slice.call(arguments, 0));
               } catch (exc) {
                 console.error(('\n✗ => ' + exc.stack + '\n').red);
-                process.exit();
+                process.exit(FAILURE_EXIT_CODE);
               }
               _passed_asserts += 1;
               _util.print('✓ '.green);


### PR DESCRIPTION
process.exit() produces an exit code of 0 (success) by default.
Explicitly defining an error code 1 on failure.

As per http://nodejs.org/api/process.html#process_process_exit_code
